### PR TITLE
fix: take into account maxZoom of both map provider and height provider

### DIFF
--- a/source/lod/LODFrustum.js
+++ b/source/lod/LODFrustum.js
@@ -42,13 +42,13 @@ export class LODFrustum extends LODRadial
 		camera.getWorldPosition(pov);
 		
 		var self = this;
-	
+		const maxZoom = Math.min (view.provider.maxZoom, view.heightProvider.maxZoom);
+		
 		view.children[0].traverse(function(node)
 		{
 			node.getWorldPosition(position);
-	
 			var distance = pov.distanceTo(position);
-			distance /= Math.pow(2, view.provider.maxZoom - node.level);
+			distance /= Math.pow(2, maxZoom - node.level);
 	
 			var inFrustum = self.pointOnly ? frustum.containsPoint(position) : frustum.intersectsObject(node);
 	

--- a/source/lod/LODFrustum.js
+++ b/source/lod/LODFrustum.js
@@ -42,13 +42,11 @@ export class LODFrustum extends LODRadial
 		camera.getWorldPosition(pov);
 		
 		var self = this;
-		const maxZoom = Math.min (view.provider.maxZoom, view.heightProvider.maxZoom);
-		
 		view.children[0].traverse(function(node)
 		{
 			node.getWorldPosition(position);
 			var distance = pov.distanceTo(position);
-			distance /= Math.pow(2, maxZoom - node.level);
+			distance /= Math.pow(2, view.provider.maxZoom - node.level);
 	
 			var inFrustum = self.pointOnly ? frustum.containsPoint(position) : frustum.intersectsObject(node);
 	

--- a/source/lod/LODRadial.js
+++ b/source/lod/LODRadial.js
@@ -41,13 +41,12 @@ export class LODRadial extends LODControl
 	
 		camera.getWorldPosition(pov);
 	
-		const maxZoom = Math.min (view.provider.maxZoom, view.heightProvider.maxZoom);
 		view.children[0].traverse(function(node)
 		{
 			node.getWorldPosition(position);
 	
 			var distance = pov.distanceTo(position);
-			distance /= Math.pow(2, maxZoom - node.level);
+			distance /= Math.pow(2, view.provider.maxZoom - node.level);
 	
 			if (distance < self.subdivideDistance)
 			{

--- a/source/lod/LODRadial.js
+++ b/source/lod/LODRadial.js
@@ -41,12 +41,13 @@ export class LODRadial extends LODControl
 	
 		camera.getWorldPosition(pov);
 	
+		const maxZoom = Math.min (view.provider.maxZoom, view.heightProvider.maxZoom);
 		view.children[0].traverse(function(node)
 		{
 			node.getWorldPosition(position);
 	
 			var distance = pov.distanceTo(position);
-			distance /= Math.pow(2, view.provider.maxZoom - node.level);
+			distance /= Math.pow(2, maxZoom - node.level);
 	
 			if (distance < self.subdivideDistance)
 			{

--- a/source/nodes/MapNode.js
+++ b/source/nodes/MapNode.js
@@ -178,7 +178,8 @@ export class MapNode extends Mesh
 	 */
 	subdivide()
 	{
-		if (this.children.length > 0 || this.level + 1 > this.mapView.provider.maxZoom || this.parentNode !== null && this.parentNode.nodesLoaded < MapNode.CHILDRENS)
+		const maxZoom = Math.min (this.mapView.provider.maxZoom, this.mapView.heightProvider.maxZoom);
+		if (this.children.length > 0 || this.level + 1 > maxZoom || this.parentNode !== null && this.parentNode.nodesLoaded < MapNode.CHILDRENS)
 		{
 			return;
 		}


### PR DESCRIPTION
This fixes issues when the height provider has a lower maxZoom as the map provider.  That way you wont have "flat" tiles.

BTW this leverage the question of do you think there would be a way to support higher `maxZoom` on map provider than on height provider?
I know it is a tough question cause we would need to "devide" the higher level height "bitmap" into 4 smaller bitmaps.
But it would allow to have highly detailed images with low height images (for example mabpox height stop at 15 when most map providers  can go higher).