### PR TITLE
fix: add rollup not properly emitting type definitions

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,7 +4,7 @@ import typescript from '@rollup/plugin-typescript';
 export default {
 	input: 'source/Main.ts',
 	plugins: [
-		typescript(),
+		typescript({ tsconfig: './tsconfig.json' }),
 		strip({
 			functions: ['assert.*', 'debug', 'alert']
 		})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,31 +1,38 @@
 {
-    "compilerOptions": {
-		"target": "ES6",
-		"module": "ES6",
-        "moduleResolution": "node",
-        "outDir": "./build",
-        "rootDir": "./source",
-		"sourceMap": true,
-		"inlineSources": false,
-		"declaration": true,
-		"allowUnreachableCode": false,
-		"allowUnusedLabels": false,
-		"emitDecoratorMetadata": true,
-		"experimentalDecorators": true,
-		"allowSyntheticDefaultImports": true,
-		"removeComments": true,
-		"alwaysStrict": true,
-		"noImplicitUseStrict": false,
-		"strictBindCallApply": true,
-		"strictFunctionTypes": true,
-		"strictPropertyInitialization": false,
-		"strictNullChecks": false,
-		"forceConsistentCasingInFileNames": true,
-		"checkJs": false,
-		"allowJs": false,
-		"esModuleInterop": true,
-		"importHelpers": false
-    },
-    "include": ["source/**/*"],
-    "exclude": ["node_modules", "docs", "build"]
+  "compilerOptions": {
+    "target": "ES6",
+    "module": "ES6",
+    "moduleResolution": "node",
+    "outDir": "./build",
+    "rootDir": "./source",
+    "sourceMap": true,
+    "inlineSources": false,
+    "declaration": true,
+    "declarationDir": ".",
+    "allowUnreachableCode": false,
+    "allowUnusedLabels": false,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "allowSyntheticDefaultImports": true,
+    "removeComments": true,
+    "alwaysStrict": true,
+    "noImplicitUseStrict": false,
+    "strictBindCallApply": true,
+    "strictFunctionTypes": true,
+    "strictPropertyInitialization": false,
+    "strictNullChecks": false,
+    "forceConsistentCasingInFileNames": true,
+    "checkJs": false,
+    "allowJs": false,
+    "esModuleInterop": true,
+    "importHelpers": false
+  },
+  "include": [
+    "source/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "docs",
+    "build"
+  ]
 }


### PR DESCRIPTION
#18 did not actually fix emitting declaration types

There seems to be an issue with rollup, (see https://github.com/rollup/plugins/issues/394)

This PR adds the workaround found at the bottom of the issue tracked in rollup and bundling with rollup will now properly emit types.