### PR TITLE
Add the module keyword to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
 	"version": "0.0.17",
 	"description": "geo-three is library for tile based geographic map layers in with three.js supporting selective loading/unloading of real-time generated 3D tiles",
 	"main": "build/geo-three.js",
+  "module": "build/geo-three.module.js",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/tentone/geothree.git"


### PR DESCRIPTION
Hi,
This should allow package bundlers that support ES Modules to import the package correctly.
Thank you!
