### PR TITLE
Dispose tile textures

### DIFF
--- a/source/nodes/MapHeightNodeShader.ts
+++ b/source/nodes/MapHeightNodeShader.ts
@@ -178,4 +178,16 @@ export class MapHeightNodeShader extends MapHeightNode
 			this.geometry = MapHeightNodeShader.geometry;
 		}
 	}
+
+	public dispose(): void
+	{
+		super.dispose();
+
+		// @ts-ignore
+		if (this.material.userData.heightMap.value && this.material.userData.heightMap.value !== MapHeightNodeShader.defaultHeightTexture)
+		{
+			// @ts-ignore
+			this.material.userData.heightMap.value.dispose();
+		}
+	}
 }

--- a/source/nodes/MapNode.ts
+++ b/source/nodes/MapNode.ts
@@ -351,6 +351,13 @@ export abstract class MapNode extends Mesh
 		{
 			const material = self.material as Material;
 			material.dispose();
+
+			// @ts-ignore
+			if (material.map && material.map !== MapNode.defaultTexture)
+			{
+				// @ts-ignore
+				material.map.dispose();
+			}
 		}
 		catch (e) {}
 		


### PR DESCRIPTION
I've read through the code and haven't found any mention of deleting old tile textures. In Three.js textures need to be deleted explicitly, see Textures section here: https://threejs.org/docs/#manual/en/introduction/How-to-dispose-of-objects

In this PR I've added `Texture.dispose()` for color textures and heightmap textures (only for `MapHeightNodeShader`). I'm not sure whether this is the best way to implement this.