### PR TITLE
Export QuadTreePosition

### DIFF
--- a/source/Main.ts
+++ b/source/Main.ts
@@ -20,7 +20,7 @@ export {MapNodeGeometry} from './geometries/MapNodeGeometry';
 export {MapNodeHeightGeometry} from './geometries/MapNodeHeightGeometry';
 export {MapSphereNodeGeometry} from './geometries/MapSphereNodeGeometry';
 
-export {MapNode} from './nodes/MapNode';
+export {MapNode, QuadTreePosition} from './nodes/MapNode';
 export {MapHeightNode} from './nodes/MapHeightNode';
 export {MapPlaneNode} from './nodes/MapPlaneNode';
 export {MapSphereNode} from './nodes/MapSphereNode';


### PR DESCRIPTION
`QuadTreePosition` export was missing in `Main.ts`. For my specific use case I need this class to create custom `MapNode`s.