### PR TITLE
Disable depth write and color write for MapView

### DIFF
--- a/source/MapView.ts
+++ b/source/MapView.ts
@@ -97,7 +97,7 @@ export class MapView extends Mesh
 	 */
 	public constructor(root: (number | MapNode) = MapView.PLANAR, provider: MapProvider = new OpenStreetMapsProvider(), heightProvider: MapProvider = null) 
 	{
-		super(undefined, new MeshBasicMaterial({transparent: true, opacity: 0.0}));
+		super(undefined, new MeshBasicMaterial({transparent: true, opacity: 0.0, depthWrite: false, colorWrite: false}));
 
 		this.lod = new LODRaycast();
 


### PR DESCRIPTION
This PR disables depth writing and color writing for MapView instances.
Even though the material is 100% transparent, it still writes depth data when rendering which can cause problems for other transparent meshes on the scene.
I've also disabled color write to explicitly specify that MapView shouldn't be visible.