### PR TITLE
Only use first intersection with the terrain

### DIFF
--- a/source/lod/LODRaycast.ts
+++ b/source/lod/LODRaycast.ts
@@ -63,7 +63,13 @@ export class LODRaycast implements LODControl
 
 			// Check intersection
 			this.raycaster.setFromCamera(this.mouse, camera);
-			this.raycaster.intersectObjects(view.children, true, intersects);
+
+			let myIntersects = [];
+			this.raycaster.intersectObjects(view.children, true, myIntersects);
+			if (myIntersects.length > 0) {
+				// Only use first intersection with the terrain
+				intersects.push(myIntersects[0]);
+			}
 		}
 
 		for (let i = 0; i < intersects.length; i++) 


### PR DESCRIPTION
I have observed that there might be more than just one intersection when doing raycasting to get the distance of the map from the camera. I guess that only the first intersection should be used to determine the LOD, right?

This situation of multiple intersections during one raycast happend when the camera was close to the ground and looking towards mountains (MapView with MapView.HEIGHT).