### PR TITLE
MapHeightNodeShader: rename vUv to vMapUv (three >= r151)

### DIFF
--- a/source/nodes/MapHeightNodeShader.ts
+++ b/source/nodes/MapHeightNodeShader.ts
@@ -85,7 +85,7 @@ export class MapHeightNodeShader extends MapHeightNode
 			#include <fog_vertex>
 	
 			// Calculate height of the title
-			vec4 _theight = texture2D(heightMap, vUv);
+			vec4 _theight = texture2D(heightMap, vMapUv);
 			float _height = ((_theight.r * 255.0 * 65536.0 + _theight.g * 255.0 * 256.0 + _theight.b * 255.0) * 0.1) - 10000.0;
 			vec3 _transformed = position + _height * normal;
 	


### PR DESCRIPTION
Hi,

Thank you for this library!
I tried using `HEIGHT_SHADER` with threejs r164 and got an error that `vUV` is undeclared.
I checked around and found that in r151 `vUV` was renamed to `vMapUv`.  
This PR fixes the error for me.

/Avner